### PR TITLE
Fix usage of Rotation.toEulerAngles()

### DIFF
--- a/freecad/gdml/exportGDML.py
+++ b/freecad/gdml/exportGDML.py
@@ -225,7 +225,12 @@ def createLVandPV(obj, name, solidName):
        ET.SubElement(define, 'position', {'name': posName, 'unit': 'mm', \
                   'x': str(x), 'y': str(y), 'z': str(z) })
     # Realthunders enhancment to toEuler ixyz is intrinsic
-    angles = obj.Placement.Rotation.toEuler('ixyz')
+    rot = obj.Placement.Rotation
+    if hasattr(rot, 'toEulerAngles'):
+        angles = rot.toEulerAngles('ixyz')
+        angles = (angles[2], angles[1], angles[0])
+    else:
+        angles = rot.toEuler()
     GDMLShared.trace("Angles")
     GDMLShared.trace(angles)
     a0 = angles[0]
@@ -616,8 +621,11 @@ def exportRotation(name, xml, Rotation) :
     global ROTcount
     if Rotation.Angle != 0 :
         # Realthunders enhancment to toEuler ixyz is intrinsic
-        angles = Rotation.toEuler('ixyz')
-        #angles = Rotation.toEuler()
+        if hasattr(Rotation, 'toEulerAngles'):
+            angles = Rotation.toEulerAngles('ixyz')
+            angles = (angles[2], angles[1], angles[0])
+        else:
+            angles = Rotation.toEuler()
         GDMLShared.trace("Angles")
         GDMLShared.trace(angles)
         a0 = angles[0]

--- a/freecad/gdml/importGDML.py
+++ b/freecad/gdml/importGDML.py
@@ -1119,7 +1119,6 @@ def expandVolume(parent,name,phylvl,displayMode) :
                      "GDML", "copynumber").CopyNumber = int(cpyNum)
               base = FreeCAD.Vector(nx,ny,nz)
               part.Placement = GDMLShared.processPlacement(base,nrot)
-       App.ActiveDocument.recompute() 
 
     else :
        asm = structure.find("assembly[@name='%s']" % name)
@@ -1428,6 +1427,7 @@ def processGDML(doc,filename,prompt,initFlg):
     if len(part.OutList) == 2 and initFlg == False :
         worldGDMLobj = part.OutList[1]
         worldGDMLobj.ViewObject.DisplayMode = 'Shaded'
+    FreeCAD.ActiveDocument.recompute()
     if FreeCAD.GuiUp :
        FreeCADGui.SendMsgToActiveView("ViewFit")
     FreeCAD.Console.PrintMessage('End processing GDML file\n')


### PR DESCRIPTION
Please make sure to test it using my branch. For your workbench, I recommend you to test with my `Daily` release with experimental renderer enabled (`Preference -> Display -> Render cache -> Experiemental`). I have just made a new release, make sure to download the image with `Daily` keyword.

Note that in the code I have reversed order of the return from `toEulerAngles()`. This is because you are exporting those angles with the wrong order, which I guess is the result of using the older `toEuler()`. I suggest you remove the use of `toEuler()` altogether and simply raise an exception if `toEulerAngles()` is not available, because, well `toEuler()` won't work anyway.

I also include a second commit to reduce call of `recompute()`. This is very important to improve performance of import. I have also added a corresponding patch to my branch to disable redraw during recompute. The combined result will greatly improve import performance. With the latest Daily release image, I was able to import the `rich_mirror` file in #40 in 6 seconds, and about 8 fps rendering performance using the experimental renderer.

The rendering performance is still not great because you are using `Link` to render large amount of relatively simply geometry, which means lots of matrix operations during rendering. Things will get better when the renderer starts to use shader for instance based rendering, but you can improve on that by yourself as well. For those containers with lots of small linked objects, you can use the group code I gave you to display a compound shape of all children, which will be rendered a lot faster.