### PR TITLE
Fix typos

### DIFF
--- a/CommandLine/convertObj.py
+++ b/CommandLine/convertObj.py
@@ -20,7 +20,7 @@
 # *                                                                        *
 # *                                                                        *
 # ***************************************************************************
-__title__ = "convertOBJ - Covert Obj to GDML Tessellated"
+__title__ = "convertOBJ - Convert Obj to GDML Tessellated"
 __author__ = "Keith Sloan <keith@sloan-home.co.uk>"
 __url__ = ["https://github.com/KeithSloan/GDML/Utils"]
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you like what you see you might like to thank Lei Zhang by contributing to hi
 ** Changes to Placement (GDML Position & Rotation) **
 
 Export of GDML objects the Position and Rotation are now a combination of the Placement of the FreeCAD App::Part (GDML Volume)
-and tghe Placement of the GDMLObject
+and the Placement of the GDMLObject
 
 ** New experimental export for GEMC**
 
@@ -77,7 +77,7 @@ Windows: if no --target option upgrade pip
 
 ### Successful installation of workbench & gmsh on Windows.
 
-User @poroserv reports successfull installation as follows
+User @poroserv reports successful installation as follows
 
 "today I installed the new GDML Workbench 2.0.0 without any problem."
 

--- a/freecad/gdml/exportGDML.py
+++ b/freecad/gdml/exportGDML.py
@@ -325,7 +325,7 @@ def quaternion2XYZ(rot):
         [      0       0       1]
 
     Rederivation from the previous version. Geant processes the rotation from
-    the gdml as R = Rz Ry Rx, i.e, Rx apllied lsat, not first, so now we have
+    the gdml as R = Rz Ry Rx, i.e, Rx applied last, not first, so now we have
 
     R = Rx Ry Rz =
         [cosb*cosg,	                -cosb*sing,	                     sinb],
@@ -721,8 +721,8 @@ def addPhysVolPlacement(obj, xmlVol, volName, placement, refName=None):
 
     # Get proper Volume Name
     # I am commenting this out I don't know why it's needed.
-    # the <volume or <assembly name is ceated withoutout any cleanup,m so the
-    # reference to it musl also not have any cleanup
+    # the <volume or <assembly name is created withoutout any cleanup,m so the
+    # reference to it must also not have any cleanup
     if refName is None:
         refName = cleanVolName(obj, volName)
     # GDMLShared.setTrace(True)
@@ -1237,7 +1237,7 @@ def getBooleanCount(obj):
 def getMaterial(obj):
     # Temporary fix until the SetMaterials works
     # Somehow (now Feb 20) if a new gdml object is added
-    # the defalut material is Geant4, and SetMaterials fails to change it
+    # the default material is Geant4, and SetMaterials fails to change it
     from .GDMLMaterials import getMaterialsList
     GDMLShared.trace('get Material : '+obj.Label)
     print(f'get Material : {obj.Label}')
@@ -1580,7 +1580,7 @@ def isAssembly(obj):
     # A terminal item CAN be a boolean, or an extrusion (and in the future
     # a chamfer or a fillet. So a terminal element need NOT have an empty
     # OutList
-    # N.B. App::Link is treated as a non-assembly, eventhough it might be linked
+    # N.B. App::Link is treated as a non-assembly, even though it might be linked
     # to an assembly, because all we need to place it is the volref of its link
 
     subObjs = []
@@ -2344,7 +2344,7 @@ class CloneExporter(SolidExporter):
         # clone no longer keepts track of the objects POSITION, but it does
         # keep track of its dimensions. So if the object is doubles in size,
         # the (scaled) double will change, but if the object is MOVED, the
-        # clone will not change its position! So the following algorith, would
+        # clone will not change its position! So the following algorithm, would
         # fail. There is no way to know if the difference between the scaled
         # position and the clone's position is due to the clone moving or the
         # object moving.
@@ -3345,7 +3345,7 @@ class PolarArrayExporter(SolidExporter):
         # TODO adjust for center of rotation != origin
         for i in range(self.obj.NumberPolar):
             rot = FreeCAD.Rotation(axis, i*dthet)
-            pos = rot*positionVector     # position has to be roated too!
+            pos = rot*positionVector     # position has to be rotated too!
             rot.Angle = -rot.Angle   # undo angle reversal by exportRotation
             nodeName = f'{self.name()}_{i}'
             nodeXML = ET.SubElement(unionXML, 'multiUnionNode', {'name': nodeName})
@@ -3499,7 +3499,7 @@ def radialExtent(edges, axis=Vector(0, 0, 1)):
     rmax = -sys.float_info.max
     for e in edges:
         b = e.BoundBox
-        for i in range(0, 8):  # loop over box bounraries
+        for i in range(0, 8):  # loop over box boundaries
             v = b.getPoint(i)
             radialVector = v - v.dot(axis) * axis
             r = radialVector.Length
@@ -3593,7 +3593,7 @@ def rotatedPos(closedCurve, rot):
     # to the Part::Extrusion Placement. However, if the placement includes
     # a rotation, Geant4 GDML would rotate the Origin-based curve THEN translate.
     # This would not work. We have to translate first THEN rotate. This method
-    # just does the needed rotation of the poisition vector
+    # just does the needed rotation of the position vector
     #
     pos = closedCurve.position
     if isinstance(closedCurve, ExtrudedCircle) or \
@@ -3617,12 +3617,12 @@ class RevolutionExporter(SolidExporter):
         return prefix + self.lastName
 
     def position(self):
-        # This presumes export has been called before postion()
+        # This presumes export has been called before position()
         # Things will be screwed up, other wise
         return self._position
 
     def rotation(self):
-        # This presumes export has been called before postion()
+        # This presumes export has been called before position()
         # Things will be screwed up, other wise
         return self._rotation
 
@@ -3636,7 +3636,7 @@ class RevolutionExporter(SolidExporter):
         # sort by largest area to smallest area
         sortEdgelistsByBoundingBoxArea(sortededges)
         # getClosedCurve returns one of the sub classes of ClosedCurve that
-        # knows how to export the specifc closed edges
+        # knows how to export the specific closed edges
         # Make names based on Revolve name
         angle = revolveObj.Angle
         axis = revolveObj.Axis
@@ -3711,7 +3711,7 @@ class RevolutionExporter(SolidExporter):
         zoffset = Vector(0, 0, 0)
         angles = quaternion2XYZ(revolveObj.Placement.Rotation)
         # need to add rotations of elliptical tubes. Assume extrusion is on z-axis
-        # Probably wil not work in general
+        # Probably will not work in general
         zAngle = angles[2] + rootRot[2]
         print(rootPos)
         print(rootCurve.name)
@@ -3892,7 +3892,7 @@ class ExtrudedEllipticalSection(ExtrudedClosedCurve):
         # In polar coordinates equation of ellipse is r(thet) = a*(1-eps*eps)/(1+eps*cos(thet))
         # if the ellipse is rotatated by an angle AngleXU, then
         # x = r*cos(thet+angleXU), y = r*sin(thet+angleXU), for thet in frame of unrotated ellipse
-        # now edge.FirstParameter is begining angle of unrotaeted ellipse
+        # now edge.FirstParameter is beginning angle of unrotated ellipse
 
         def sqr(x):
             return x*x
@@ -3919,7 +3919,7 @@ class ExtrudedEllipticalSection(ExtrudedClosedCurve):
         # In polar coordinates equation of ellipse is r(thet) = a*(1-eps*eps)/(1+eps*cos(thet))
         # if the ellipse is rotatated by an angle AngleXU, then
         # x = r*cos(thet+angleXU), y = r*sin(thet+angleXU), for thet in frame of unrotated ellipse
-        # now edge.FirstParameter is begining angle of unrotaeted ellipse
+        # now edge.FirstParameter is beginning angle of unrotated ellipse
         # polar equation of ellipse, with r measured from FOCUS. Focus at a*eps
         # r = lambda thet: a*(1-eps*eps)/(1+eps*math.cos(thet))
         # polar equation of ellipse, with r measured from center a*eps
@@ -4107,7 +4107,7 @@ class ExtrudedNEdges(ExtrudedClosedCurve):
         withoutArea = fwithout.Area
         print(f'totArea {totArea}, edgeArea {edgeArea}, withoutArea {withoutArea}')
 
-        if totArea < 0.999*(edgeArea + withoutArea):  # 0.99 saftey margin for totArea = edgeArea+withoutArea
+        if totArea < 0.999*(edgeArea + withoutArea):  # 0.99 safety margin for totArea = edgeArea+withoutArea
             if totArea > edgeArea:
                 return True
             else:
@@ -4356,12 +4356,12 @@ class ExtrusionExporter(SolidExporter):
         Deviation = self.obj.ViewObject.Deviation/100.0
 
     def position(self):
-        # This presumes export has been called before postion()
+        # This presumes export has been called before position()
         # Things will be screwed up, other wise
         return self._position
 
     def rotation(self):
-        # This presumes export has been called before postion()
+        # This presumes export has been called before position()
         # Things will be screwed up, other wise
         return self._rotation
 
@@ -4382,7 +4382,7 @@ class ExtrusionExporter(SolidExporter):
         # sort by largest area to smallest area
         sortEdgelistsByBoundingBoxArea(sortededges)
         # getCurve returns one of the sub classes of ClosedCurve that
-        # knows how to export the specifc closed edges
+        # knows how to export the specific closed edges
         # Make names based on Extrude name
         # curves = [getCurve(edges, extrudeObj.Label + str(i)) for i, edges
         # in enumerate(sortededges)]
@@ -4461,7 +4461,7 @@ class ExtrusionExporter(SolidExporter):
 
         angles = quaternion2XYZ(extrudeObj.Placement.Rotation)
         # need to add rotations of elliptical tubes. Assume extrusion is on z-axis
-        # Probably wil not work in general
+        # Probably will not work in general
         zAngle = angles[2] + rootRot[2]
         rootPos = rotatedPos(rootCurve, extrudeObj.Placement.Rotation)
         print(rootPos)

--- a/freecad/gdml/importGDML.py
+++ b/freecad/gdml/importGDML.py
@@ -185,7 +185,7 @@ def setDisplayMode(obj, mode):
 
 def newPartFeature(obj, name):
     newobj = obj.newObject("Part::FeaturePython", name)
-    # FreeCAD can change the name i.e. hypen to underscore
+    # FreeCAD can change the name i.e. hyphen to underscore
     # So also set the Objects Label
     newobj.Label = name
     return(newobj)
@@ -193,7 +193,7 @@ def newPartFeature(obj, name):
 
 def newGroupPython(obj, name):
     newobj = obj.newObject("App::DocumentObjectGroupPython", name)
-    # FreeCAD can change the name i.e. hypen to underscore
+    # FreeCAD can change the name i.e. hyphen to underscore
     # So also set the Objects Label
     newobj.Label = name
     return(newobj)


### PR DESCRIPTION
Found via `codespell -q 3 -L alph,ba,falt,focu,nd,parm,parms,ro,te,vertexes`