### PR TITLE
Fix multi-component mixture parsing and custom material enumeration

### DIFF
--- a/freecad/gdml/GDMLCommands.py
+++ b/freecad/gdml/GDMLCommands.py
@@ -810,24 +810,16 @@ class AddMaterial(QtGui.QDialog):
 
         if not self.checkGDMLDoc():
             return
-
-        match = re.match(self.mixturePattern, expr)
-        groups = match.groups()
-
+            
         mixtureDict = {}
-        i = 0  # 0 means the item is a fraction, 1 means the item is a Material name
-        for s in groups:
-            if s is None:
-                continue
-            if i == 0:
-                frac = float(s)
-                i = 1 - i
-                continue
-            if i == 1:
-                material = s
-                mixtureDict[material] = frac
-                i = 1 - i
+        
+        # Parse every fraction/material pair independently.
+        pairPattern = r'(\d+(?:\.\d*)?|\.\d+)\s+([A-Za-z][A-Za-z0-9_]*)'
+        pairs = re.findall(pairPattern, expr)
 
+        for frac, material in pairs:
+            mixtureDict[material] = float(frac)
+        
         # step 1: verify that all materials already exist
         exportGeant4Materials = False
         for mat in dict(mixtureDict):  # parse a copy, since we may need to change the material name

--- a/freecad/gdml/GDMLObjects.py
+++ b/freecad/gdml/GDMLObjects.py
@@ -161,32 +161,34 @@ def checkMaterial(material):
         return False
     return True
 
-
 def setMaterial(obj, m):
-    # print(f'setMaterial {obj} {m}')
+    global MaterialsList
+
+    # Rebuild the material list from the current document
+    # so newly created custom materials are available.
+    MaterialsList.clear()
+    rebuildMaterialsList()
+
     if FreeCAD.GuiUp:
         if m in ['G4_AIR', 'AIR']:
             print(f"Material {m}")
             if hasattr(obj, "ViewObject"):
                 print("Set transparency")
                 obj.ViewObject.Transparency = 98
+    
+    if MaterialsList is not None and len(MaterialsList) > 0:
+        obj.material = MaterialsList
+        obj.material = 0
+    
+        if not (m == 0 or m is None):
+            try:
+                obj.material = MaterialsList.index(m)
+            except ValueError:
+                print("Material not in List:", m)
+                print(MaterialsList)
+                obj.material = 0
 
-    if MaterialsList is not None:
-        if len(MaterialsList) > 0:
-            obj.material = MaterialsList
-            obj.material = 0
-            if not (m == 0 or m is None):
-                try:
-                    obj.material = MaterialsList.index(m)
-                except:
-                    print("Not in List")
-                    print(MaterialsList)
-                    obj.material = 0
-                return
-            return
-    rebuildMaterialsList()
-    setMaterial(obj, m)
-
+        return
 
 def checkFullCircle(aunit, angle):
     # print(angle)


### PR DESCRIPTION
## Problem

On FreeCAD 1.1.1 with the GDML Workbench, I encountered two issues while creating GDML materials for Geant4/GRAS radiation analysis.

### 1. Multi-component mixture parsing
Multi-component material mixtures were parsed using repeated regex capture groups with 'match.groups()'. This caused only part of a mixture to be processed correctly.

For example:
0.8732 Al + 0.0040 Si + 0.0050 Fe + 0.0200 Cu + 0.0030 Mn + 0.0028 Cr + 0.0290 Mg + 0.0610 Zn + 0.0020 Ti

### 2. Custom materials missing from GDML solid material lists
Newly created custom materials were available in the Materials group but were not appearing in the material enumeration of newly created GDML solids such as GDMLTube.

### Changes
1. Parse each fraction/material pair independently using re.findall().
2. Rebuild the material list from the current document before populating GDML material enumerations.

### Testing
Tested locally on FreeCAD 1.1.1.
1. Verified a 9-component Al-7075 mixture.
2. Verified that all fractions are preserved correctly.
3. Verified that newly created custom materials appear in the GDMLTube material dropdown.